### PR TITLE
Fix parsing of match context

### DIFF
--- a/company-racer.el
+++ b/company-racer.el
@@ -114,7 +114,7 @@ If non nil overwrites the value of the environment variable 'RUST_SRC_PATH'."
 
 (defun company-racer-parse-candidate (line)
   "Return a completion candidate from a LINE."
-  (let* ((match (and (string-prefix-p "MATCH" line) (cadr (split-string line " "))))
+  (let* ((match (and (string-prefix-p "MATCH" line) (string-join (cdr (split-string line " ")) " ")))
          (values (and match (split-string match ","))))
     (and values
          (cl-multiple-value-bind (matchstr line column filepath matchtype contextstr) values


### PR DESCRIPTION
Matches can contain multiple whitespaces. Don't drop the tokens after
the second.

E.g.: note that the space after "pub" would mean that the contextstr of the match is just "pub" instead of the full function signature.

`MATCH copy,49,7,/home/lbolla/.multirust/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src/libstd/io/util.rs,Function,pub fn copy<R: ?Sized, W: ?Sized>(reader: &mut R, writer: &mut W) -> io::Result<u64> where R: Read, W: Write
`